### PR TITLE
Fix GHCR cache access

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,6 +206,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary
- login to ghcr.io before pulling build cache in linux-build

## Testing
- `go test ./...` *(fails: context deadline due to heavy build)*

------
https://chatgpt.com/codex/tasks/task_e_6855ebe4eb24832c93acaf50e2b18d2d