### PR TITLE
Disable Windows auto update

### DIFF
--- a/app/lifecycle/updater.go
+++ b/app/lifecycle/updater.go
@@ -24,7 +24,9 @@ import (
 )
 
 var (
-	UpdateCheckURLBase  = "https://ollama.com/api/update"
+	// UpdateCheckURLBase is intentionally left blank in this fork to
+	// disable automatic updates to the upstream project.
+	UpdateCheckURLBase  = ""
 	UpdateDownloaded    = false
 	UpdateCheckInterval = 60 * 60 * time.Second
 )
@@ -200,6 +202,10 @@ func cleanupOldDownloads() {
 }
 
 func StartBackgroundUpdaterChecker(ctx context.Context, cb func(string) error) {
+	if UpdateCheckURLBase == "" {
+		slog.Info("automatic update check disabled")
+		return
+	}
 	go func() {
 		// Don't blast an update message immediately after startup
 		// time.Sleep(30 * time.Second)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## How can I upgrade Ollama?
 
-Ollama on macOS and Windows will automatically download updates. Click on the taskbar or menubar item and then click "Restart to update" to apply the update. Updates can also be installed by downloading the latest version [manually](https://ollama.com/download/).
+Ollama on macOS will automatically download updates. This fork disables automatic updates on Windows. Click on the menubar item and then click "Restart to update" on macOS, or download the latest version [manually](https://ollama.com/download/) to upgrade.
 
 On Linux, re-run the install script:
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -75,8 +75,9 @@ The Ollama Windows installer registers an Uninstaller application.  Under `Add o
 
 The easiest way to install Ollama on Windows is to use the `OllamaSetup.exe`
 installer. It installs in your account without requiring Administrator rights.
-We update Ollama regularly to support the latest models, and this installer will
-help you keep up to date.
+The official release of Ollama uses this installer to keep the application up to
+date automatically. This fork disables the automatic update feature, so you will
+need to download newer versions manually.
 
 If you'd like to install or integrate Ollama as a service, a standalone
 `ollama-windows-amd64.zip` zip file is available containing only the Ollama CLI


### PR DESCRIPTION
## Summary
- disable Windows auto update by leaving `UpdateCheckURLBase` blank and bailing out of the checker
- note lack of auto update in Windows docs
- mention macOS automatic update only in FAQ

## Testing
- `go test ./...` *(fails: unsupported protocol scheme or takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_6856696c6e98832cb95c10c61593981e